### PR TITLE
make yum group file option relative to repoPath

### DIFF
--- a/yumfile.go
+++ b/yumfile.go
@@ -315,9 +315,16 @@ func (c *Yumfile) createrepo(repo *Repo) error {
 	if DebugMode {
 		args = append(args, "--verbose")
 	}
-
+	
+	// set path to create repo for
+	repoPath :=fmt.Sprintf("./%s", repo.ID)
+	if repo.LocalPath != "" {
+		repoPath = repo.LocalPath
+	}
+	
+	// Set groupfile, relative to the repoPath
 	if repo.Groupfile != "" {
-		args = append(args, fmt.Sprintf("--groupfile=%s", repo.Groupfile))
+		args = append(args, fmt.Sprintf("--groupfile=%s/%s", repoPath, repo.Groupfile))
 	}
 
 	// non-default checksum type
@@ -326,12 +333,8 @@ func (c *Yumfile) createrepo(repo *Repo) error {
 	}
 
 	// path to create repo for
-	if repo.LocalPath != "" {
-		args = append(args, repo.LocalPath)
-	} else {
-		args = append(args, fmt.Sprintf("./%s", repo.ID))
-	}
-
+	args = append(args, repoPath)
+	
 	// execute and capture output
 	if err := Exec("createrepo", args...); err != nil {
 		return err


### PR DESCRIPTION
allow to define 

```
pathprefix=/mirror

[centos7-os]
name=centos 7 - x86_64
localpath=centos/7/os/x86_64
groupfile=comps.xml
```
and have the groupfile relative to the local path, as reposync places it in localpath

produces f.i. as per above yum file

```
createrepo --update --database --checkts --cachedir=/mirror/reposync/tmp/cache/repo/centos6 --workers=8 --profile --verbose --groupfile=/mirror/centos/6/os/x86_64/comps.xml /mirror/centos/7/os/x86_64
```